### PR TITLE
로드밸런싱용 Docker Swarm 세팅 추가

### DIFF
--- a/client/app/main.py
+++ b/client/app/main.py
@@ -14,14 +14,13 @@ def index():
 @app.route('/get_score', methods=['POST'])
 def get_score():
     data = request.json
-    res = requests.post(f'http://dkt-inference-server:5000/predict', json= data) # Set BentoML serve port to 5000(default)
+    # request to loadbalancer -> reverse server : inference container
+    res = requests.post(f'http://inference:5000/predict', json= data)
     score = res.text
     score = int(float(score))
     print(score)
 
     return str(score)
-
-# TODO Retrain by API request? or Cron Job by Airflow?
 
 if __name__ == '__main__':
     app.run(host="0.0.0.0", port=6006, debug=True)

--- a/client/app/main.py
+++ b/client/app/main.py
@@ -1,3 +1,5 @@
+import sys
+
 from flask import Flask, render_template
 from flask import request
 
@@ -14,8 +16,7 @@ def index():
 @app.route('/get_score', methods=['POST'])
 def get_score():
     data = request.json
-    # request to loadbalancer -> reverse server : inference container
-    res = requests.post(f'http://inference:5000/predict', json= data)
+    res = requests.post("http://inference:5000/predict", json= data)
     score = res.text
     score = int(float(score))
     print(score)

--- a/client/start.sh
+++ b/client/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 app="dkt-client-flask"
 docker build -t ${app} .
-docker run -d -p 6006:6006 \
-  --name=${app} ${app}
+docker run -p 6006:6006 \
+  --name=${app} --network bento_serving_mentos ${app}
 # for volumne mount(access to host storage)
 #  -v ${PWD}/app:/app ${app}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
-version: '3'
+version: "3.7"
 
 services:
+
   client:
     image: kpic5014/dkt-client-flask
     container_name: dkt-client
@@ -8,11 +9,43 @@ services:
       - "80:6006"
     networks:
       - mentos
+
+  reverse-proxy:
+    image: traefik:v2.4
+    container_name: reverse-proxy
+    environment:
+      - TRAEFIK_ACCESSLOG=true
+    command:
+      - "--api.insecure=true"
+      - "--api.dashboard=true"
+      - "--api.debug=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.model.address=:80" # ! traefik listening port
+    ports:
+      - "7000:80"
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+#      - ./reverse_proxy/traefik.toml:/traefik.toml
+    networks:
+      - mentos
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.api.rule=Host(`traefik.dashboard`)" # ! route url to dashboard
+      - "traefik.http.routers.api.service=api@internal"
+
   inference:
     image: kpic5014/bento-dkt
-    container_name: dkt-inference-server
     ports:
-      - "5000:5000"
+      - "7000:5000"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.inference.entrypoints=model"
+      - "traefik.http.routers.inference.rule=Host(`inference`)" # ! route url to bentodkt
+      - "traefik.http.services.client.loadbalancer.server.port=5000" # ! inference container listening port
+#      - "traefik.backend=inference"
+#      - "traefik.backend.healthcheck.path=/health"
+#      - "traefik.backend.healthcheck.interval=1s"
     networks:
       - mentos
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,51 +4,27 @@ services:
 
   client:
     image: kpic5014/dkt-client-flask
-    container_name: dkt-client
     ports:
       - "80:6006"
     networks:
       - mentos
 
-  reverse-proxy:
-    image: traefik:v2.4
-    container_name: reverse-proxy
-    environment:
-      - TRAEFIK_ACCESSLOG=true
-    command:
-      - "--api.insecure=true"
-      - "--api.dashboard=true"
-      - "--api.debug=true"
-      - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.model.address=:80" # ! traefik listening port
-    ports:
-      - "7000:80"
-      - "8080:8080"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-#      - ./reverse_proxy/traefik.toml:/traefik.toml
-    networks:
-      - mentos
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.api.rule=Host(`traefik.dashboard`)" # ! route url to dashboard
-      - "traefik.http.routers.api.service=api@internal"
-
   inference:
+    # deploy option for container orchestration(Docker Swarm)
+    deploy:
+      replicas: 3 # CUSTOM IT!
+      resources:
+        limits:
+          cpus: "0.3" # CUSTOM IT!
+          memory: "300M" # CUSTOM IT!
+      restart_policy:
+        condition: on-failure
     image: kpic5014/bento-dkt
     ports:
-      - "7000:5000"
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.inference.entrypoints=model"
-      - "traefik.http.routers.inference.rule=Host(`inference`)" # ! route url to bentodkt
-      - "traefik.http.services.client.loadbalancer.server.port=5000" # ! inference container listening port
-#      - "traefik.backend=inference"
-#      - "traefik.backend.healthcheck.path=/health"
-#      - "traefik.backend.healthcheck.interval=1s"
+      - "5000:5000"
     networks:
       - mentos
 
 networks:
   mentos:
-    driver: bridge
+    driver: overlay

--- a/docker_manual/service-init.sh
+++ b/docker_manual/service-init.sh
@@ -1,0 +1,19 @@
+# Initialize Docker Swarm Cluster(& Manager Node)
+docker swarm init
+# Run specified Services(each Service has multiple container replicas) in <docker-compose.yml> as name <dkt-service>
+docker stack deploy -c docker-compose.yml dkt-service
+
+# Running Services in Dockker Swarm Cluster
+echo "All Services are running ... Below is Running Services which current manage node tracks."
+docker service ls
+
+# You can get Service logs by executing next line.
+# docker service logs -f <SERVICE-NAME>
+
+# You can update(rolling-update) service with new image by executing next line.
+#docker service update \
+#  --update-parallelism 1 \
+#  --update-delay 10s \
+#  --image kpic5014/dkt-client-flask:latest \
+#  --detach=false \
+#  dkt-service_client


### PR DESCRIPTION
하나의 Flask 서버가 3개의 BentoML Model Server에 연결되도록 했습니다.
docker manual의 shell script를 이용해 초기세팅을 수행하고, 이후 Airflow로 업데이트 시도합니다.